### PR TITLE
感圧板の上にブロックが乗ると跳ねるバグ修正

### DIFF
--- a/Assets/Scripts/Map/GenerateMap.cs
+++ b/Assets/Scripts/Map/GenerateMap.cs
@@ -37,7 +37,8 @@ public class GenerateMap : MonoBehaviour
     List<int> bootObjectID;                     // ギミック起動オブジェクトid
     Dictionary<int, int> gimmickAssociationID;  // ギミックを起動オブジェクトに紐付けるためのid    
 
-    string stageName = "1-1";
+    string stageName = "1-1";   // ステージ名
+    public string StageName { private get { return stageName; } set { stageName = value; } }    // ステージ名のプロパティ
 
     //関数--------------------------------------------------------------------------
     // Start is called before the first frame update
@@ -50,7 +51,7 @@ public class GenerateMap : MonoBehaviour
             //ステージ名を取得する
 
             //jsonファイルを読み込んでデータを取得する
-            loadJsonFile.GetStageData(stageName, this);
+            loadJsonFile.GetStageData(StageName, this);
         }
 
         //値の初期値設定
@@ -126,7 +127,7 @@ public class GenerateMap : MonoBehaviour
                                 break;
 
                             case 5:     // 感圧板を生成する
-                                position = new Vector3(x, y - 0.5f, (layerHeight - 1) - z); // 0.5引くことで生成時に床の上に生成される
+                                position = new Vector3(x, y - 0.4f, (layerHeight - 1) - z); // 0.5引くことで生成時に床の上に生成される
                                 startUpObjectInstances.Add(Instantiate(prefab, position, Quaternion.identity));
                                 break;
 


### PR DESCRIPTION
原因
床に埋まったboxColliderに乗せると上方向に力が加わっていた。おそらくUnity2022.2.9のバグっぽい

解決方法
感圧板を地面に埋まらないよう生成するようにした