### PR TITLE
透明ブロックのギミックを動かす感圧板を2つ以上押してしまったときに透明に戻ってしまうバグを修正

### DIFF
--- a/Assets/Prefabs/Gimmicks/PressurePlate.prefab
+++ b/Assets/Prefabs/Gimmicks/PressurePlate.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 7934692659357464598}
   - component: {fileID: 7520654099676963188}
   - component: {fileID: 2686554836960587671}
-  - component: {fileID: 6777250401609787176}
+  - component: {fileID: 3871011479258608788}
   m_Layer: 0
   m_Name: PressurePlate
   m_TagString: Untagged
@@ -156,7 +156,7 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 126
   m_CollisionDetection: 0
---- !u!114 &6777250401609787176
+--- !u!114 &3871011479258608788
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -165,6 +165,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 405261439610448840}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f99920331a91a41933a867aa095164, type: 3}
+  m_Script: {fileID: 11500000, guid: 061e6db0b60ced547894e51ed3e42eff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 

--- a/Assets/Scenes/GimmickScene.unity
+++ b/Assets/Scenes/GimmickScene.unity
@@ -835,7 +835,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 7784192296233873562, guid: 11cc012f2db954f468d20bd3fd3a057a,
         type: 3}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 6777250401609787176, guid: e267045e0aec5d14ea2d1517537bd6ae, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []

--- a/Assets/Scripts/Gimmicks/BlockSpawner/GenerateBlock.cs
+++ b/Assets/Scripts/Gimmicks/BlockSpawner/GenerateBlock.cs
@@ -18,37 +18,42 @@ public class GenerateBlock : GimmickBase, IStartedOperation
     //ブロックが無ければブロックを生成する
     public void ProcessWhenPressed()
     {
-        if (generatingBlockPrefab)
+        //一度処理したら感圧板等を押し続けている場合は押すのをやめるまで処理しない
+        if (HasRunningOnce())
         {
-            //生成したブロックが消滅していたらリストから削除しておく
-            generatedBlocks.RemoveAll(block => block == null);
-
-            //ブロックが生成されていなかったら生成する
-            if(generatedBlocks.Count < maxObjects)
+            if (generatingBlockPrefab)
             {
-                //生成位置を決める
-                Vector3 position = transform.position;
+                //生成したブロックが消滅していたらリストから削除しておく
+                generatedBlocks.RemoveAll(block => block == null);
 
-                //ブロックの生成
-                GameObject newBlock = Instantiate(generatingBlockPrefab, position, Quaternion.identity);
+                //ブロックが生成されていなかったら生成する
+                if (generatedBlocks.Count < maxObjects)
+                {
+                    //生成位置を決める
+                    Vector3 position = transform.position;
 
-                //生成したブロックをリストに登録
-                generatedBlocks.Add(newBlock);
+                    //ブロックの生成
+                    GameObject newBlock = Instantiate(generatingBlockPrefab, position, Quaternion.identity);
+
+                    //生成したブロックをリストに登録
+                    generatedBlocks.Add(newBlock);
+                }
+                else
+                {
+                    Debug.LogWarning("既に生成されている");
+                }
             }
             else
             {
-                Debug.LogWarning("既に生成されている");
+                Debug.LogWarning("生成するオブジェクトが設定されていない");
             }
-        }
-        else
-        {
-            Debug.LogWarning("生成するオブジェクトが設定されていない");
         }
     }
 
     public void ProcessWhenStopped()
     {
-        //処理なし
+        //また感圧板などを押したらギミックを起動できるようにする
+        MakeToLaunchable();
     }
 
     //void Update()

--- a/Assets/Scripts/Gimmicks/DealDamageObjects/DamageBlock/DamageBlock.cs
+++ b/Assets/Scripts/Gimmicks/DealDamageObjects/DamageBlock/DamageBlock.cs
@@ -45,13 +45,17 @@ public class DamageBlock : DealDamageObjectBase, IStartedOperation
 
     public void ProcessWhenPressed()
     {
-        //ダメージを受けないようにする
-        isCauseDamage = false;
-
-        //マテリアルの色変更
-        if(material)
+        //一度処理したら感圧板等を押し続けている場合は押すのをやめるまで処理しない
+        if (HasRunningOnce())
         {
-            material.color = blockColor[1];
+            //ダメージを受けないようにする
+            isCauseDamage = false;
+
+            //マテリアルの色変更
+            if (material)
+            {
+                material.color = blockColor[1];
+            }
         }
     }
 
@@ -65,6 +69,9 @@ public class DamageBlock : DealDamageObjectBase, IStartedOperation
         {
             material.color = blockColor[0];
         }
+
+        //また感圧板などを押したらギミックを起動できるようにする
+        MakeToLaunchable();
     }
 
     //setter関数

--- a/Assets/Scripts/Gimmicks/DealDamageObjects/LaserBlock/LaserBlock.cs
+++ b/Assets/Scripts/Gimmicks/DealDamageObjects/LaserBlock/LaserBlock.cs
@@ -77,12 +77,16 @@ public class LaserBlock : DealDamageObjectBase, IStartedOperation
 
     public void ProcessWhenPressed()
     {
-        //レーザーの発射をやめる
-        shouldToPutLaser = false;
-
-        if(lineRenderer)
+        //一度処理したら感圧板等を押し続けている場合は押すのをやめるまで処理しない
+        if (HasRunningOnce())
         {
-            lineRenderer.enabled = false;
+            //レーザーの発射をやめる
+            shouldToPutLaser = false;
+
+            if (lineRenderer)
+            {
+                lineRenderer.enabled = false;
+            }
         }
     }
 
@@ -95,5 +99,8 @@ public class LaserBlock : DealDamageObjectBase, IStartedOperation
         {
             lineRenderer.enabled = true;
         }
+
+        //また感圧板などを押したらギミックを起動できるようにする
+        MakeToLaunchable();
     }
 }

--- a/Assets/Scripts/Gimmicks/GimmickBase.cs
+++ b/Assets/Scripts/Gimmicks/GimmickBase.cs
@@ -6,6 +6,7 @@ public class GimmickBase : MonoBehaviour
 {
     //変数
     public int id { get; private set; }         // インスタンス毎に持つid
+    private bool isRunning = false;             // すでにギミックが起動しているか(感圧板等でギミックが一度だけ動く場合に使用)
 
     //関数
     /// <summary>
@@ -15,5 +16,34 @@ public class GimmickBase : MonoBehaviour
     public void SetID(int id)
     {
         this.id = id;
+    }
+
+    /// <summary>
+    /// 一度感圧板等でギミックが起動されているか判定する(これを使うとき、ギミックの起動をやめたときの処理にMakeToLaunchable()を書く)
+    /// </summary>
+    /// <returns></returns>
+    protected bool HasRunningOnce()
+    {
+        //押された瞬間はギミックを起動させる
+        if(!isRunning)
+        {
+            isRunning = true;
+            return true;
+        }
+
+        //すでに押した後だったら押すのをやめるまでギミックを起動しないようにする
+        return false;
+    }
+
+    /// <summary>
+    /// 感圧板等で一度だけ起動するギミックを再び起動できるようにする
+    /// </summary>
+    protected void MakeToLaunchable()
+    {
+        //ギミックが起動されているか確認する
+        if (isRunning)
+        {
+            isRunning = false;
+        }
     }
 }

--- a/Assets/Scripts/Gimmicks/PressurePlate/GimmickBoot_PressurePlate.cs
+++ b/Assets/Scripts/Gimmicks/PressurePlate/GimmickBoot_PressurePlate.cs
@@ -2,13 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class StartOtherObjectProcess_StepOn : BootObjectBase, ISetGimmickInstance
+public class GimmickBoot_PressurePlate : BootObjectBase, ISetGimmickInstance
 {
     //変数
     List<GameObject> targetObjects = new List<GameObject>(); // 処理を行わせるオブジェクト
     bool isOnce = false;            // 一度だけしか押せないか(処理しないか)決める
     bool isPressed;                 // 押されたかを記憶する
-    
 
     void Start()
     {
@@ -17,7 +16,7 @@ public class StartOtherObjectProcess_StepOn : BootObjectBase, ISetGimmickInstanc
     }
 
     //感圧板を押したとき
-    void OnTriggerEnter(Collider other)
+    void OnTriggerStay(Collider other)
     {
         if(!isPressed)
         {

--- a/Assets/Scripts/Gimmicks/PressurePlate/GimmickBoot_PressurePlate.cs.meta
+++ b/Assets/Scripts/Gimmicks/PressurePlate/GimmickBoot_PressurePlate.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 59f99920331a91a41933a867aa095164
+guid: 061e6db0b60ced547894e51ed3e42eff
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Gimmicks/TransparencyBlock/TransparencyAndSubstantiation.cs
+++ b/Assets/Scripts/Gimmicks/TransparencyBlock/TransparencyAndSubstantiation.cs
@@ -38,16 +38,20 @@ public class TransparencyAndSubstantiation : GimmickBase, IStartedOperation
     //透明化、または実体化する
     public void ProcessWhenPressed()
     {
-        //透明化しているとき
-        if(isTransparentize)
+        //一度処理したら感圧板等を押し続けている場合は押すのをやめるまで処理しない
+        if (HasRunningOnce())
         {
-            Substantiation();
-        }
-        //透明化していないとき
-        else
-        {
-            //透明化する
-            Transparency();
+            //透明化しているとき
+            if (isTransparentize)
+            {
+                Substantiation();
+            }
+            //透明化していないとき
+            else
+            {
+                //透明化する
+                Transparency();
+            }
         }
     }
 
@@ -65,6 +69,9 @@ public class TransparencyAndSubstantiation : GimmickBase, IStartedOperation
             //透明化する
             Transparency();
         }
+
+        //また感圧板などを押したらギミックを起動できるようにする
+        MakeToLaunchable();
     }
 
     /// <summary>

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -135,8 +135,7 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 0.1.0
-  preloadedAssets:
-  - {fileID: 11400000, guid: 9b73da3d645c1e54ca406f83d3633f34, type: 2}
+  preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
バグ原因
透明かどうかのbool型変数をif文で判断し、それで透明にするか実態にするか判断しており、すでにギミックを起動しているか判断する条件式が無かったため起きてしまっていた。

解決
すでにギミックを起動しているか判断する条件式を追加した

補足
実体ブロックでも同じ原因でバグが起きていたので修正されている

おまけ
感圧板のOnTriggerEnterをOnTriggerStayに変更したので押している間はギミックの処理を呼ぶようになった。 (押し続ける必要のあるギミックを実装しやすくした)