### PR TITLE
レーザーを生成するとマップが生成できなくなってしまうバグ修正

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -166,9 +166,6 @@ MonoBehaviour:
   - {fileID: 4251495620201291638, guid: 70181243728a84a41b4bdccaa6d10e7c, type: 3}
   - {fileID: 53740106535157207, guid: 5462d867dbab0a44ca17bb4922b5d722, type: 3}
   - {fileID: 3467628863430339497, guid: 6ef8139e040dce244a421737b3f57076, type: 3}
-  - {fileID: 3467628863430339497, guid: 6ef8139e040dce244a421737b3f57076, type: 3}
-  - {fileID: 3467628863430339497, guid: 6ef8139e040dce244a421737b3f57076, type: 3}
-  - {fileID: 3467628863430339497, guid: 6ef8139e040dce244a421737b3f57076, type: 3}
   - {fileID: 7784192296233873562, guid: 11cc012f2db954f468d20bd3fd3a057a, type: 3}
 --- !u!4 &243274140
 Transform:
@@ -758,7 +755,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   pauseScreen: {fileID: 6350569512814578303, guid: fa899ac1d22733b4db13f658e6c18796,
     type: 3}
-  canvas: {fileID: 1949641259}
 --- !u!1 &1130665835
 GameObject:
   m_ObjectHideFlags: 0
@@ -949,6 +945,7 @@ MonoBehaviour:
     type: 3}
   gameOverPrefab: {fileID: 7796390757591306710, guid: e22fc1674ea69ca40b87094f34cb8e21,
     type: 3}
+  fade: {fileID: 0}
 --- !u!1 &1351277290
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Map/GenerateMap.cs
+++ b/Assets/Scripts/Map/GenerateMap.cs
@@ -14,7 +14,7 @@ public class GenerateMap : MonoBehaviour
         gimmickID = new List<int>();
         bootObjectID = new List<int>();
         gimmickAssociationID = new Dictionary<int, int>();
-        rotationValue_y = new List<float>();
+        rotationValue_y = new List<int>();
     }
 
     //変数--------------------------------------------------------------------------
@@ -37,7 +37,7 @@ public class GenerateMap : MonoBehaviour
     List<int> gimmickID;                        // ギミックid
     List<int> bootObjectID;                     // ギミック起動オブジェクトid
     Dictionary<int, int> gimmickAssociationID;  // ギミックを起動オブジェクトに紐付けるためのid    
-    List<float> rotationValue_y;
+    List<int> rotationValue_y;
 
     //関数--------------------------------------------------------------------------
     // Start is called before the first frame update
@@ -201,7 +201,7 @@ public class GenerateMap : MonoBehaviour
     /// <param name="gimmickAssociationKey"> ギミックを起動オブジェクトに紐づけるためのkey </param>
     /// <param name="gimmickAssociationID"> ギミックを起動オブジェクトに紐づけるためのid </param>
     /// <param name="rotationValue_y"> ギミックのy軸回転の値 </param>
-    public void SetStageData(int layerWidth, int layerHeight, int layerNumber, List<List<List<int>>> mapData, List<int> gimmickID, List<int> bootObjectID, List<int> gimmickAssociationKey, List<int> gimmickAssociationID, List<float> rotationValue_y)
+    public void SetStageData(int layerWidth, int layerHeight, int layerNumber, List<List<List<int>>> mapData, List<int> gimmickID, List<int> bootObjectID, List<int> gimmickAssociationKey, List<int> gimmickAssociationID, List<int> rotationValue_y)
     {
         this.layerWidth = layerWidth;
         this.layerHeight = layerHeight;

--- a/Assets/Scripts/Map/LoadJsonFile_Map.cs
+++ b/Assets/Scripts/Map/LoadJsonFile_Map.cs
@@ -103,10 +103,10 @@ public class LoadJsonFile_Map : MonoBehaviour
             }
 
             //y軸回転情報の格納
-            List<float> rotationValue_y = new List<float>();
+            List<int> rotationValue_y = new List<int>();
             for(int i = 0; i < (int)jsonData["MapDataInfo"][0]["DirectionNum"]; ++i)
             {
-                rotationValue_y.Add((float)jsonData["MapDataInfo"][0]["Direction"][i]);
+                rotationValue_y.Add((int)jsonData["MapDataInfo"][0]["Direction"][i]);
             }
 
             //ステージを作るのに必要な情報を設定する


### PR DESCRIPTION
原因
y軸回転情報がJsonDataにint型として扱われており、それをfloat型にcastしようとしたため

解決
float型のcastからint型のcastに変更

補足
LitJsonではfloat型のcastは直接は不可能
先にdouble型等にcastしてからfloat型にcastすることは可能